### PR TITLE
List applications

### DIFF
--- a/forestserviceprototype/forestserviceprototype/urls.py
+++ b/forestserviceprototype/forestserviceprototype/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^submit/$', views.submit, name="submit"),
     url(r'^submitted/$', views.submitted_permit, name="submitted_permit"),
+    url(r'^applications/', views.applications, name="applications"),
 ]

--- a/forestserviceprototype/specialuseform/forms.py
+++ b/forestserviceprototype/specialuseform/forms.py
@@ -8,8 +8,8 @@ class PermitForm(forms.ModelForm):
         model = Permit
         fields = ['event_name', 'organizer_address_1', 'organizer_address_2', 'city', 'state', 'zipcode', 'phone_daytime', 'phone_evening', 'description', 'location', 'participant_number', 'spectator_number', 'start_date', 'end_date', 'permit_holder_name', 'permit_holder_signature']
         widgets = {
-            'start_date': forms.SelectDateWidget,
-            'end_date': forms.SelectDateWidget,
+#            'start_date': forms.SelectDateWidget,
+#            'end_date': forms.SelectDateWidget,
             'phone_daytime': forms.PhoneNumberInput,
             'phone_evening': forms.PhoneNumberInput
         }

--- a/forestserviceprototype/specialuseform/templates/specialuseform/applications.html
+++ b/forestserviceprototype/specialuseform/templates/specialuseform/applications.html
@@ -1,0 +1,10 @@
+{% extends "specialuseform/base.html" %}
+
+{% block content %}
+  <h1>Applications</h1>
+  {% for permit in permits %}
+  <p class="usa-font-lead">
+    {{ permit.event_name }}
+  </p>
+  {% endfor %}
+{% endblock content %}

--- a/forestserviceprototype/specialuseform/templates/specialuseform/applications.html
+++ b/forestserviceprototype/specialuseform/templates/specialuseform/applications.html
@@ -2,9 +2,28 @@
 
 {% block content %}
   <h1>Applications</h1>
-  {% for permit in permits %}
-  <p class="usa-font-lead">
-    {{ permit.event_name }}
-  </p>
-  {% endfor %}
+  {% if permits %}
+      <table>
+        <thead>
+            <tr>
+                <th scope="col">Event name</th>
+                <th scope="col">Location</th>
+                <th scope="col">Start date</th>
+                <th scope="col">End date</th>
+                <th scope="col">Created</th>
+                <th scope="col">Status</th>
+            <tr>
+        </thead>
+      {% for permit in permits %}
+        <tr>
+            <th scope="row">{{ permit.event_name }}</th>
+            <td>{{ permit.location }}</td>
+            <td>{{ permit.start_date }}</td>
+            <td>{{ permit.end_date }}</td>
+            <td>{{ permit.created }}</td>
+            <td>{{ permit.status }}</td>
+        </tr>
+      {% endfor %}
+      </table>
+  {% endif %}
 {% endblock content %}

--- a/forestserviceprototype/specialuseform/views.py
+++ b/forestserviceprototype/specialuseform/views.py
@@ -15,3 +15,9 @@ def submit(request):
 
 def submitted_permit(request):
     return render(request, "specialuseform/submitted_permit.html")
+
+def applications(request):
+    permits = Permit.objects.all()
+    return render(request, "specialuseform/applications.html", {
+        'permits': permits
+        })

--- a/forestserviceprototype/specialuseform/views.py
+++ b/forestserviceprototype/specialuseform/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import HttpResponse
 from .forms import PermitForm
@@ -16,6 +17,8 @@ def submit(request):
 def submitted_permit(request):
     return render(request, "specialuseform/submitted_permit.html")
 
+# @todo: Fix redirect so users don't get stuck in admin screen. See #7.
+@login_required(login_url='/admin/')
 def applications(request):
     permits = Permit.objects.all()
     return render(request, "specialuseform/applications.html", {


### PR DESCRIPTION
This PR minimally addresses #2. It creates an `/applications/` page which can be viewed only by logged-in users.

<img width="1099" alt="screen shot 2016-09-22 at 5 19 42 pm" src="https://cloud.githubusercontent.com/assets/1244599/18770496/8483ba16-80eb-11e6-97db-d0ec2630eb22.png">

Possible TODOs include:
- Add a link to the actual submission
- Meaningfully sort the submissions
- Rework `status` column so it's human-readable, not just machine-readable
- Rework `created` column to be `__ days ago`, perhaps with highlighting of applications that have been waiting a while
