### PR TITLE
[WIP] Enable applicant to view application [contents and] status.

### DIFF
--- a/forestserviceprototype/forestserviceprototype/urls.py
+++ b/forestserviceprototype/forestserviceprototype/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^submit/$', views.submit, name="submit"),
     url(r'^submitted/$', views.submitted_permit, name="submitted_permit"),
+    url(r'^permit/(?P<permit_id>[0-9]+)/$', views.permit, name="permit"),
     url(r'^applications/', views.applications, name="applications"),
 ]

--- a/forestserviceprototype/specialuseform/models.py
+++ b/forestserviceprototype/specialuseform/models.py
@@ -9,7 +9,7 @@ class Permit(models.Model):
         ('needs_approval', 'Needs Approval'),
         ('approved', 'Approved'),
         ('in_review', 'In Review'),
-        ('not_approved', 'Not Approved')
+        ('not_approved', 'Rejected')
     )
     event_name = models.CharField(max_length=250,
         help_text='The name of the event')

--- a/forestserviceprototype/specialuseform/templates/specialuseform/permit.html
+++ b/forestserviceprototype/specialuseform/templates/specialuseform/permit.html
@@ -1,0 +1,49 @@
+{% extends "specialuseform/base.html" %}
+
+{% block content %}
+  <h1>Your permit</h1>
+  <p class="usa-font-lead">
+      <strong>Status:</strong> {{ permit.get_status_display }}
+  </p>
+  <p>
+      <em>Questions? Contact XYZ.</em>
+  </p>
+  <h3>Event name:</h3>
+  <p>
+    {{ permit.event_name }}
+  </p>
+  <h3>Organizer address:</h3>
+  <p>
+    {{ permit.organizer_address_1 }}<br />
+    {{ permit.organizer_address_2 }}<br />
+    {{ permit.city }}, {{ permit.state }}  {{ permit.zipcode }}
+  </p>
+  <h3>Phone number(s):</h3>
+  <p>
+    {{ permit.phone_daytime }}<br />
+    {{ permit.phone_evening }}
+  </p>
+  <h3>Description:</h3>
+  <p>
+    {{ permit.description }}
+  </p>
+  <h3>Location:</h3>
+  <p>
+    {{ permit.location }}
+  </p>
+  <h3>Number of people:</h3>
+  <p>
+    {{ permit.participant_number }} participant{{ permit.participant_number|pluralize }}<br />
+    {{ permit.spectator_number }} spectator{{permit.spectator_number|pluralize }}
+  </p>
+  <h3>When:</h3>
+  <p>
+    {{ permit.start_date }} {% if permit.end_date != permit.start_date %} through {{ permit.end_date }} {% endif %}
+  </p>
+  <h3>Submitted by:</h3>
+  <p>
+    {{ permit.permit_holder_name }}<br />
+    {{ permit.permit_holder_signature }}<br />
+    {{ permit.created }}
+  </p>
+{% endblock %}

--- a/forestserviceprototype/specialuseform/views.py
+++ b/forestserviceprototype/specialuseform/views.py
@@ -17,6 +17,12 @@ def submit(request):
 def submitted_permit(request):
     return render(request, "specialuseform/submitted_permit.html")
 
+def permit(request, permit_id):
+    permit = get_object_or_404(Permit.objects.filter(id=permit_id))
+    return render(request, "specialuseform/permit.html", {
+        'permit': permit
+        })
+
 # @todo: Fix redirect so users don't get stuck in admin screen. See #7.
 @login_required(login_url='/admin/')
 def applications(request):


### PR DESCRIPTION
This PR closes #6 by adding a new page at `/permit/PERMIT_ID` where an applicant (or anyone) can view their permit application's content and status.

Remaining TODOs before review:
- [ ] Update requirements.
- [ ] Consider rendering field labels programmatically.

Further steps:
- Rework submission confirmation such that after the applicant submits an application, they're redirected to `/permit/[PERMIT_ID]`. Then remove the `/submitted` route from `urls.py`.
- Consider rendering as a table instead of as sections. Which would be more readable?

Caveats:
- Currently, the URL is 100 percent hackable and would reveal PII if used in the wild. This is a quick and simple solution for prototype purposes only. If using this for real, implement access controls.
- Haven't yet verified applicant signature rendering.

The screenshots below are misaligned. Disregard the left margin jump that starts at `Description`.

---

<img width="830" alt="screen shot 2016-09-26 at 11 43 10 am" src="https://cloud.githubusercontent.com/assets/1244599/18847363/d1b0f4fc-83de-11e6-8b64-c1a6dc123d4c.png">
<img width="801" alt="screen shot 2016-09-26 at 11 43 36 am" src="https://cloud.githubusercontent.com/assets/1244599/18847362/d19ad4ba-83de-11e6-948d-f6291ffa3f21.png">
