### PR TITLE
Change `Not Approved` to `Rejected`

### DIFF
--- a/forestserviceprototype/specialuseform/models.py
+++ b/forestserviceprototype/specialuseform/models.py
@@ -9,7 +9,7 @@ class Permit(models.Model):
         ('needs_approval', 'Needs Approval'),
         ('approved', 'Approved'),
         ('in_review', 'In Review'),
-        ('not_approved', 'Not Approved')
+        ('not_approved', 'Rejected')
     )
     event_name = models.CharField(max_length=250,
         help_text='The name of the event')


### PR DESCRIPTION
`Rejected` may sound harsh, but it's meant to be clearer than `Not Approved`, which could be interpreted as either `Not Yet Reviewed (and Approved)` or `(Reviewed and) Not Approved`. Feel free to iterate further.

https://github.com/18F/forest-service-prototype/issues/6
