### PR TITLE
Add Waffle board to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Forest Service Prototype
 This is a Django application to test out an online permit of the non-commercial group use Forest Service Permit.
 
+For the clearest view of issue priorities and status, check [this Waffle board](waffle.io/18F/forest-service-prototype).
+
 ## Local Installation
 
 This app is designed to run on Python 3.5.2. `pyenv` is recommended for managing


### PR DESCRIPTION
Filing this PR against `master` because it's what people see first on the GitHub repo's web interface. This commit can readily be reapplied to `develop` too.
