### PR TITLE
Correct location of manage.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ mkvirtualenv forest-service-prototype
 pip install -r requirements.txt
 createdb forest-service-prototype
 cd forestserviceprototype
-./manage.py migrate
-./manage.py runserver
+forestserviceprototype/manage.py migrate
+forestserviceprototype/manage.py runserver
 ```
 
 The app should now be running at http://localhost:8000.


### PR DESCRIPTION
Updates installation instructions to reflect that `manage.py` is inside the nested `forestserviceprototype` directory.
