### PR TITLE
Fixing Waffle URL in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This non-commercial group use permit prototype is being developed as part of ini
 
 In general, this prototype is driven by the goals, users and features set forward at a special uses permitting kick-off workshop. Read more in the [special uses workshop summary](https://github.com/18F/forest-service-prototype/raw/master/docs/special-uses-read-out.pdf). In a few weeks, we will kick off a similar discovery effort for Christmas tree permits. Read more in the [Christmas tree workshop summary](https://github.com/18F/forest-service-prototype/raw/master/docs/christmas-tree-read-out.pdf).
 
-For the clearest view of issue priorities and status, check [this Waffle board](waffle.io/18F/forest-service-prototype).
+For the clearest view of issue priorities and status, check [this Waffle board](https://waffle.io/18F/forest-service-prototype).
 
 ## Local Installation
 


### PR DESCRIPTION
Adding a "https://" to the Waffle URL link so it works.
